### PR TITLE
Add an implementation in Crystal

### DIFF
--- a/Crystal/Makefile
+++ b/Crystal/Makefile
@@ -1,0 +1,12 @@
+CRYSTAL_BIN ?= $(shell which crystal)
+
+.PHONY: all clean
+
+%: %.cr
+	$(CRYSTAL_BIN) build --release --no-debug $<
+	strip $@
+
+all: walk
+
+clean:
+	-rm -f walk

--- a/Crystal/walk.cr
+++ b/Crystal/walk.cr
@@ -1,6 +1,6 @@
 def main(dirpath)
   count = 0
-  Dir[dirpath + "/**/*"].each do |path|
+  Dir.glob(dirpath + "/**/*") do |path|
       filetype = File.info(path, follow_symlinks: false).type
       if filetype.file? && path.downcase.ends_with?(".jpg")
         count += 1

--- a/Crystal/walk.cr
+++ b/Crystal/walk.cr
@@ -1,0 +1,12 @@
+def main(dirpath)
+  count = 0
+  Dir[dirpath + "/**/*"].each do |path|
+      filetype = File.info(path, follow_symlinks: false).type
+      if filetype.file? && path.downcase.ends_with?(".jpg")
+        count += 1
+      end
+  end
+  count
+end
+
+puts main(ARGV[0])

--- a/Go_3rd/Makefile
+++ b/Go_3rd/Makefile
@@ -1,4 +1,9 @@
-.PHONY: all clean
+.PHONY: all clean depends
+
+default: depends walk
+
+depends:
+	go get github.com/karrick/godirwalk
 
 %: %.go
 	go build -ldflags "-w -s" $<

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all clean
 
-languages = Go Go_3rd Rust
+languages = Crystal Go Go_3rd Rust
 
 all: $(languages)
 

--- a/benchmark.toml
+++ b/benchmark.toml
@@ -5,6 +5,8 @@ time_limit = 30
 count_limit = 20
 valid_percent = 50
 
+[item.Crystal]
+
 [item.Go]
 
 [item.Go_3rd]


### PR DESCRIPTION
This is a result in my Arch Linux x86_64 for a small dataset:

```
$ ../swapview/run_benchmark Crystal Go Go_3rd Python Python2 Rust <benchmark.toml 
Running Crystal...Ok(BenchmarkResult { topavg: 165806667, avg: 170036143, min: 163329268, max: 182448074, mdev: 5205681, count: 20 })
Running Go...Ok(BenchmarkResult { topavg: 199023682, avg: 208528696, min: 177594405, max: 229517343, mdev: 12087341, count: 20 })
Running Go_3rd...Ok(BenchmarkResult { topavg: 91463349, avg: 93995290, min: 88332118, max: 99816685, mdev: 3122527, count: 20 })
Running Python...Ok(BenchmarkResult { topavg: 189661013, avg: 192611708, min: 184566094, max: 200845073, mdev: 3974274, count: 20 })
Running Python2...Ok(BenchmarkResult { topavg: 282163355, avg: 286277760, min: 278530204, max: 308868004, mdev: 6509942, count: 20 })
Running Rust...Ok(BenchmarkResult { topavg: 66761983, avg: 70252466, min: 65288837, max: 76324756, mdev: 3693138, count: 20 })
                    Rust: top:   66.76, min:   65.29, avg:   70.25, max:   76.32, mdev:    3.69, cnt:  20
                  Go_3rd: top:   91.46, min:   88.33, avg:   94.00, max:   99.82, mdev:    3.12, cnt:  20
                 Crystal: top:  165.81, min:  163.33, avg:  170.04, max:  182.45, mdev:    5.21, cnt:  20
                  Python: top:  189.66, min:  184.57, avg:  192.61, max:  200.85, mdev:    3.97, cnt:  20
                      Go: top:  199.02, min:  177.59, avg:  208.53, max:  229.52, mdev:   12.09, cnt:  20
                 Python2: top:  282.16, min:  278.53, avg:  286.28, max:  308.87, mdev:    6.51, cnt:  20
```

with rustc 1.35.0, go 1.12.6, Python 3.7.3, Python 2.7.16 and Crystal 0.29.0.